### PR TITLE
Add touch friendly layout

### DIFF
--- a/Eyedropper.UWP/Eyedropper.Properties.cs
+++ b/Eyedropper.UWP/Eyedropper.Properties.cs
@@ -22,16 +22,6 @@ namespace Eyedropper.UWP
             DependencyProperty.Register(nameof(WorkArea), typeof(Rect), typeof(Eyedropper),
                 new PropertyMetadata(default(Rect), OnWorkAreaChanged));
 
-        // Using a DependencyProperty as the backing store for ImageGridRow.  This enables animation, styling, binding, etc...
-        public static readonly DependencyProperty ImageGridRowProperty =
-            DependencyProperty.Register(nameof(ImageGridRow), typeof(int), typeof(Eyedropper),
-                new PropertyMetadata(default(int)));
-
-        // Using a DependencyProperty as the backing store for ColorGridRow.  This enables animation, styling, binding, etc...
-        public static readonly DependencyProperty ColorGridRowProperty =
-            DependencyProperty.Register(nameof(ColorGridRow), typeof(int), typeof(Eyedropper),
-                new PropertyMetadata(default(int)));
-
         public Color Color
         {
             get => (Color) GetValue(ColorProperty);
@@ -49,18 +39,6 @@ namespace Eyedropper.UWP
         {
             get => (Rect) GetValue(WorkAreaProperty);
             set => SetValue(WorkAreaProperty, value);
-        }
-
-        public int ImageGridRow
-        {
-            get => (int)GetValue(ImageGridRowProperty);
-            set => SetValue(ImageGridRowProperty, value);
-        }
-
-        public int ColorGridRow
-        {
-            get => (int)GetValue(ColorGridRowProperty);
-            set => SetValue(ColorGridRowProperty, value);
         }
 
         public static void OnColorChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)

--- a/Eyedropper.UWP/Eyedropper.Properties.cs
+++ b/Eyedropper.UWP/Eyedropper.Properties.cs
@@ -22,6 +22,16 @@ namespace Eyedropper.UWP
             DependencyProperty.Register(nameof(WorkArea), typeof(Rect), typeof(Eyedropper),
                 new PropertyMetadata(default(Rect), OnWorkAreaChanged));
 
+        // Using a DependencyProperty as the backing store for ImageGridRow.  This enables animation, styling, binding, etc...
+        public static readonly DependencyProperty ImageGridRowProperty =
+            DependencyProperty.Register(nameof(ImageGridRow), typeof(int), typeof(Eyedropper),
+                new PropertyMetadata(default(int)));
+
+        // Using a DependencyProperty as the backing store for ColorGridRow.  This enables animation, styling, binding, etc...
+        public static readonly DependencyProperty ColorGridRowProperty =
+            DependencyProperty.Register(nameof(ColorGridRow), typeof(int), typeof(Eyedropper),
+                new PropertyMetadata(default(int)));
+
         public Color Color
         {
             get => (Color) GetValue(ColorProperty);
@@ -39,6 +49,18 @@ namespace Eyedropper.UWP
         {
             get => (Rect) GetValue(WorkAreaProperty);
             set => SetValue(WorkAreaProperty, value);
+        }
+
+        public int ImageGridRow
+        {
+            get => (int)GetValue(ImageGridRowProperty);
+            set => SetValue(ImageGridRowProperty, value);
+        }
+
+        public int ColorGridRow
+        {
+            get => (int)GetValue(ColorGridRowProperty);
+            set => SetValue(ColorGridRowProperty, value);
         }
 
         public static void OnColorChanged(DependencyObject d, DependencyPropertyChangedEventArgs e)

--- a/Eyedropper.UWP/Eyedropper.cs
+++ b/Eyedropper.UWP/Eyedropper.cs
@@ -176,13 +176,11 @@ namespace Eyedropper.UWP
             UpdateEyedropper(point.Position);
             if (e.Pointer.PointerDeviceType == Windows.Devices.Input.PointerDeviceType.Touch)
             {
-                ColorGridRow = 0;
-                ImageGridRow = 2;
+                VisualStateManager.GoToState(this, "TouchState", false);
             }
             else
             {
-                ColorGridRow = 2;
-                ImageGridRow = 0;
+                VisualStateManager.GoToState(this, "MousePenState", false);
             }
 
             if (Opacity < 1) Opacity = 1;

--- a/Eyedropper.UWP/Eyedropper.cs
+++ b/Eyedropper.UWP/Eyedropper.cs
@@ -174,6 +174,16 @@ namespace Eyedropper.UWP
             await UpdateAppScreenshotAsync();
             var point = e.GetCurrentPoint(_rootGrid);
             UpdateEyedropper(point.Position);
+            if (e.Pointer.PointerDeviceType == Windows.Devices.Input.PointerDeviceType.Touch)
+            {
+                ColorGridRow = 0;
+                ImageGridRow = 2;
+            }
+            else
+            {
+                ColorGridRow = 2;
+                ImageGridRow = 0;
+            }
 
             if (Opacity < 1) Opacity = 1;
         }

--- a/Eyedropper.UWP/Themes/Generic.xaml
+++ b/Eyedropper.UWP/Themes/Generic.xaml
@@ -169,12 +169,14 @@
                         <Grid Padding="5">
                             <Grid.RowDefinitions>
                                 <RowDefinition />
+                                <RowDefinition Height="5" />
                                 <RowDefinition Height="Auto" />
                             </Grid.RowDefinitions>
                             <Grid
+                                Grid.Row="{TemplateBinding ImageGridRow}"
                                 Width="100"
                                 Height="100"
-                                Margin="0,0,0,5">
+                                Margin="0">
                                 <Image Source="{TemplateBinding Preview}" />
                                 <Grid>
                                     <Grid.RowDefinitions>
@@ -194,7 +196,7 @@
                                         StrokeThickness="1" />
                                 </Grid>
                             </Grid>
-                            <Grid Grid.Row="1">
+                            <Grid Grid.Row="{TemplateBinding ColorGridRow}">
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="Auto" />
                                     <ColumnDefinition />

--- a/Eyedropper.UWP/Themes/Generic.xaml
+++ b/Eyedropper.UWP/Themes/Generic.xaml
@@ -173,7 +173,8 @@
                                 <RowDefinition Height="Auto" />
                             </Grid.RowDefinitions>
                             <Grid
-                                Grid.Row="{TemplateBinding ImageGridRow}"
+                                x:Name="imageGrid"
+                                Grid.Row="0"
                                 Width="100"
                                 Height="100"
                                 Margin="0">
@@ -196,7 +197,7 @@
                                         StrokeThickness="1" />
                                 </Grid>
                             </Grid>
-                            <Grid Grid.Row="{TemplateBinding ColorGridRow}">
+                            <Grid x:Name="colorGrid" Grid.Row="2">
                                 <Grid.ColumnDefinitions>
                                     <ColumnDefinition Width="Auto" />
                                     <ColumnDefinition />
@@ -218,6 +219,22 @@
                                     Text="{Binding Color, RelativeSource={RelativeSource Mode=TemplatedParent}, Mode=OneWay}" />
                             </Grid>
                         </Grid>
+                        <VisualStateManager.VisualStateGroups>
+                            <VisualStateGroup>
+                                <VisualState x:Name="MousePenState">
+                                    <VisualState.Setters>
+                                        <Setter Target="imageGrid.(Grid.Row)" Value="0" />
+                                        <Setter Target="colorGrid.(Grid.Row)" Value="2" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                                <VisualState x:Name="TouchState">
+                                    <VisualState.Setters>
+                                        <Setter Target="imageGrid.(Grid.Row)" Value="2" />
+                                        <Setter Target="colorGrid.(Grid.Row)" Value="0" />
+                                    </VisualState.Setters>
+                                </VisualState>
+                            </VisualStateGroup>
+                        </VisualStateManager.VisualStateGroups>
                     </Border>
                 </ControlTemplate>
             </Setter.Value>


### PR DESCRIPTION
I found that trying to invoke the eyedropper using touch usually results in my own fat finger blocking the color hex code / preview, as the following artist rendition shows:
![image](https://user-images.githubusercontent.com/9416356/53726740-79d09100-3e23-11e9-866e-2126e69bf8ef.png)
I made a small change to detect when the user is using touch and flip the layout in those instances, to ensure that the hex code is always visible:
![image](https://user-images.githubusercontent.com/9416356/53726960-f82d3300-3e23-11e9-93cf-3052380a9fd6.png)

